### PR TITLE
close #33 implement base response dto for all endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/serve-static": "^5.0.2",
     "@nestjs/typeorm": "^11.0.0",
     "@types/passport-google-oauth20": "^2.0.16",
     "argon2": "^0.41.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,8 @@ import { AuthModule } from './auth/auth.module';
 import { MaterialsModule } from './materials/materials.module';
 import { CommentsModule } from './comments/comments.module';
 import databaseConfig from 'db.config';
+import { ServeStaticModule } from '@nestjs/serve-static';
+import { join } from 'path';
 
 @Module({
   imports: [
@@ -18,6 +20,10 @@ import databaseConfig from 'db.config';
       isGlobal: true,
     }),
     TypeOrmModule.forRootAsync(databaseConfig.asProvider()),
+    ServeStaticModule.forRoot({
+      rootPath: join(__dirname, '..', 'uploads'),
+      serveRoot: '/uploads',
+    }),
     PostsModule,
     UsersModule,
     AuthModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,59 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { ValidationPipe } from '@nestjs/common';
-import * as express from 'express';
-import * as path from 'path';
+import {
+  ClassSerializerInterceptor,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  app.enableCors();
-  app.useGlobalPipes(new ValidationPipe());
-  app.enableCors(); // Enable CORS
-  const PORT = process.env.PORT ?? 3000;
+  try {
+    const app = await NestFactory.create(AppModule);
 
-  // Serve static files from the 'uploads' folder.
-  app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));
+    // Configure global settings
+    setupGlobalConfig(app);
 
-  await app.listen(PORT);
+    // Start the server
+    await startServer(app);
+  } catch (error) {
+    console.error('Error during bootstrap:', error);
+    process.exit(1);
+  }
 }
 
-bootstrap();
+function setupGlobalConfig(app: INestApplication): void {
+  app.enableCors({
+    origin: ['http://localhost:3000'],
+  });
+
+  // Global pipes
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
+
+  // Global interceptors
+  app.useGlobalInterceptors(
+    new ClassSerializerInterceptor(app.get(Reflector), {
+      excludePrefixes: ['_'],
+    }),
+  );
+}
+
+async function startServer(app: INestApplication): Promise<void> {
+  const configService = app.get(ConfigService);
+  const port = configService.get<number>('PORT', 3001);
+
+  await app.listen(port);
+  console.log(`Application is running on: http://localhost:${port}`);
+}
+
+bootstrap().catch((error) => {
+  console.error('Failed to bootstrap application:', error);
+  process.exit(1);
+});

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsString,
   IsArray,
+  IsUrl,
 } from 'class-validator';
 import { PostType } from '../enums/post-type.enum';
 import { PostDifficulty } from '../enums/post-difficulty.enum';
@@ -28,6 +29,7 @@ export class CreatePostDto {
 
   @IsString()
   @IsOptional()
+  @IsUrl()
   thumbnailUrl?: string;
 
   @IsEnum(PostType)

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -30,7 +30,13 @@ export class PostsController {
       { name: 'thumbnail', maxCount: 1 },
     ]),
   )
-  async uploadFiles(@UploadedFiles() files: { images?: Express.Multer.File[]; thumbnail?: Express.Multer.File[] }) {
+  async uploadFiles(
+    @UploadedFiles()
+    files: {
+      images?: Express.Multer.File[];
+      thumbnail?: Express.Multer.File[];
+    },
+  ) {
     return this.postsService.uploadFiles(files);
   }
 
@@ -57,11 +63,13 @@ export class PostsController {
 
   @Public()
   @Get('uploads/:filename')
-  async getUploadedFile(@Param('filename') filename: string, @Res() res: Response) {
+  async getUploadedFile(
+    @Param('filename') filename: string,
+    @Res() res: Response,
+  ) {
     return this.postsService.getUploadedFile(filename, res);
   }
 
-  // Update a post, allowing new file uploads
   @Public()
   @Patch(':id')
   @UseInterceptors(
@@ -73,7 +81,11 @@ export class PostsController {
   async update(
     @Param('id') id: string,
     @Body() updatePostDto: UpdatePostDto,
-    @UploadedFiles() files?: { images?: Express.Multer.File[]; thumbnail?: Express.Multer.File[] },
+    @UploadedFiles()
+    files?: {
+      images?: Express.Multer.File[];
+      thumbnail?: Express.Multer.File[];
+    },
   ) {
     return this.postsService.update(+id, updatePostDto, files);
   }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { Repository } from 'typeorm';
@@ -19,21 +23,31 @@ export class PostsService {
     return await this.postRepository.save(post);
   }
 
-  async findAll() {
-    return await this.postRepository.find();
+  async findAll(): Promise<Post[]> {
+    const posts = await this.postRepository.find();
+
+    return posts;
   }
 
-  async findOne(id: number) {
+  async findOne(id: number): Promise<Post> {
     const post = await this.postRepository.findOne({ where: { id } });
+
     if (!post) {
       throw new NotFoundException(`Post with ID ${id} not found`);
     }
+
     return post;
   }
 
-  async update(id: number, updatePostDto: UpdatePostDto, files?: { images?: Express.Multer.File[]; thumbnail?: Express.Multer.File[] }) {
-    let post = await this.findOne(id); // Ensure post exists
-
+  async update(
+    id: number,
+    updatePostDto: UpdatePostDto,
+    files?: {
+      images?: Express.Multer.File[];
+      thumbnail?: Express.Multer.File[];
+    },
+  ) {
+    const post = await this.postRepository.findOne({ where: { id } });
     if (files) {
       const { imageUrls, thumbnailUrl } = this.uploadFiles(files);
       if (imageUrls.length > 0) {
@@ -49,22 +63,35 @@ export class PostsService {
   }
 
   async remove(id: number) {
-    const post = await this.findOne(id);
-    await this.postRepository.remove(post);
+    const post = await this.postRepository.findOneBy({ id });
+
+    if (!post) {
+      throw new NotFoundException(`Post with ID ${id} not found`);
+    }
+
+    return await this.postRepository.remove(post);
   }
 
-  uploadFiles(files: { images?: Express.Multer.File[]; thumbnail?: Express.Multer.File[] }) {
+  uploadFiles(files: {
+    images?: Express.Multer.File[];
+    thumbnail?: Express.Multer.File[];
+  }) {
     console.log('Files received (upload service):', files);
 
     const images = files?.images || [];
     const thumbnailFiles = files?.thumbnail || [];
 
     if (images.length === 0 && thumbnailFiles.length === 0) {
-      throw new BadRequestException('At least one image or thumbnail should be uploaded');
+      throw new BadRequestException(
+        'At least one image or thumbnail should be uploaded',
+      );
     }
 
     const imageUrls = images.map((file) => `/uploads/${file.filename}`);
-    const thumbnailUrl = thumbnailFiles.length > 0 ? `/uploads/${thumbnailFiles[0].filename}` : null;
+    const thumbnailUrl =
+      thumbnailFiles.length > 0
+        ? `/uploads/${thumbnailFiles[0].filename}`
+        : null;
 
     return { imageUrls, thumbnailUrl };
   }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,6 +1,7 @@
 import { BeforeInsert, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import * as argon2 from 'argon2';
 import { Role } from 'src/auth/enums/role.enum';
+import { Exclude } from 'class-transformer';
 
 @Entity('users')
 export class User {
@@ -19,8 +20,8 @@ export class User {
   @Column({ unique: true, type: 'varchar', length: 40 })
   email: string;
 
-  @Column()
-  password: string;
+  @Column({ name: 'password' })
+  _password: string;
 
   @Column({ nullable: true })
   profileImageUrl: string;
@@ -31,11 +32,12 @@ export class User {
   @Column({ type: 'enum', enum: Role, default: Role.USER })
   role: Role;
 
+  @Exclude()
   @Column({ nullable: true })
   hashedRefreshToken: string;
 
   @BeforeInsert()
   async hashPassword() {
-    this.password = await argon2.hash(this.password);
+    this._password = await argon2.hash(this._password);
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -8,7 +8,6 @@ import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
-import { omit } from 'lodash';
 
 @Injectable()
 export class UsersService {
@@ -17,8 +16,7 @@ export class UsersService {
   async create(createUserDto: CreateUserDto): Promise<User> {
     const user = this.usersRepo.create(createUserDto);
     try {
-      const savedUser = await this.usersRepo.save(user);
-      return omit(savedUser, ['password', 'hashedRefreshToken']) as User;
+      return await this.usersRepo.save(user);
     } catch (error) {
       throw new InternalServerErrorException(
         `Failed to create user. ${error.message}`,
@@ -27,16 +25,11 @@ export class UsersService {
   }
 
   async findAll(): Promise<User[]> {
-    return await this.usersRepo.find({
-      select: ['id', 'email', 'firstName', 'lastName', 'role'],
-    });
+    return await this.usersRepo.find();
   }
 
   async findOne(id: number): Promise<User> {
-    return await this.usersRepo.findOne({
-      where: { id },
-      select: ['id', 'email', 'hashedRefreshToken', 'role'],
-    });
+    return await this.usersRepo.findOneBy({ id });
   }
 
   async findByEmail(email: string): Promise<User> {
@@ -65,6 +58,10 @@ export class UsersService {
   }
 
   async updateRefreshToken(id: number, hashedRefreshToken: string) {
+    if (!id) {
+      throw new InternalServerErrorException('User ID is required');
+    }
+
     return this.usersRepo.update(id, { hashedRefreshToken });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,6 +746,13 @@
     jsonc-parser "3.3.1"
     pluralize "8.0.0"
 
+"@nestjs/serve-static@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/serve-static/-/serve-static-5.0.2.tgz#2d878078dcf564245b705f5b60f17de695bd7cdd"
+  integrity sha512-MvgBQ691s8cIIsr7w4gE3NiUghCsD+1d/njqEG83M4U/9+WeczCgjrsgHTtGFYMBYBMysXQ9ni6VsUiSdzKtrQ==
+  dependencies:
+    path-to-regexp "8.2.0"
+
 "@nestjs/testing@^10.0.0":
   version "10.4.15"
   resolved "https://registry.yarnpkg.com/@nestjs/testing/-/testing-10.4.15.tgz#4c9fe17bf026c0142040cbe3db464c526f89d36a"
@@ -4234,6 +4241,11 @@ path-to-regexp@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
   integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
+
+path-to-regexp@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.2.0.tgz#73990cc29e57a3ff2a0d914095156df5db79e8b4"
+  integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
 
 path-type@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
I have changes response behavior. Instead of creating new separate dto class for just which will be annoying, for this project size. I have reuse the entity class for the response. You can either annotate with `@Exclude` decorator or use underscore in front of field name. Example: _password.

Notice: You might need to add `@Column({ name: 'password' })` to save those field with a proper column name into database. Check `user.entity.ts` for reference.